### PR TITLE
Photos

### DIFF
--- a/backend/gncitizen/core/sites/models.py
+++ b/backend/gncitizen/core/sites/models.py
@@ -87,8 +87,8 @@ class MediaOnVisitModel(TimestampMixinModel, db.Model):
 
     __tablename__ = "cor_visites_media"
     __table_args__ = {"schema": "gnc_sites"}
-    id_cor_visit_media = db.Column(db.Integer, primary_key=True, unique=True)
-    id_visit = db.Column(
+    id_match = db.Column(db.Integer, primary_key=True, unique=True)
+    id_data_source = db.Column(
         db.Integer,
         db.ForeignKey(VisitModel.id_visit, ondelete="SET NULL"),
         nullable=False,

--- a/backend/gncitizen/core/sites/routes.py
+++ b/backend/gncitizen/core/sites/routes.py
@@ -92,6 +92,7 @@ def get_site_photos(site_id):
     ).all()
     return [{
                 'url': '/media/{}'.format(p.MediaModel.filename),
+                'date': p.VisitModel.as_dict()['date'],
             } for p in photos]
 
 

--- a/backend/gncitizen/core/sites/routes.py
+++ b/backend/gncitizen/core/sites/routes.py
@@ -93,6 +93,7 @@ def get_site_photos(site_id):
     return [{
                 'url': '/media/{}'.format(p.MediaModel.filename),
                 'date': p.VisitModel.as_dict()['date'],
+                'author': p.VisitModel.obs_txt,
             } for p in photos]
 
 

--- a/backend/gncitizen/core/sites/routes.py
+++ b/backend/gncitizen/core/sites/routes.py
@@ -81,7 +81,8 @@ def get_site(pk):
 
 def get_site_photos(site_id):
     photos = db.session.query(
-        MediaModel
+        MediaModel,
+        VisitModel,
     ).filter(
         VisitModel.id_site == site_id
     ).join(
@@ -89,10 +90,9 @@ def get_site_photos(site_id):
     ).join(
         VisitModel, VisitModel.id_visit == MediaOnVisitModel.id_data_source
     ).all()
-    return [
-        "/api/media/{}".format(p.filename)
-        for p in photos
-    ]
+    return [{
+                'url': '/media/{}'.format(p.MediaModel.filename),
+            } for p in photos]
 
 
 def format_site(site):

--- a/backend/tests/common.py
+++ b/backend/tests/common.py
@@ -66,12 +66,16 @@ def auth():
     return json.dumps(myParams)
 
 
-def postrequest(url, params=None):
+def postrequest(url, params=None, file=None):
     myUrl = mainUrl + url
     h = headers.copy()
     if access_token:
         h.update({'Authorization': 'Bearer {}'.format(access_token)})
-    response = requests.post(myUrl, headers=h, data=params)
+    files = None
+    if file is not None:
+        files = {'file': open(file, 'rb')}
+        del h['Content-Type'] # let requests set proper Content-Type with boundaries
+    response = requests.post(myUrl, headers=h, data=params, files=files)
     return response
 
 

--- a/backend/tests/test_sites.py
+++ b/backend/tests/test_sites.py
@@ -121,7 +121,7 @@ class VisitsTestCase(unittest.TestCase):
         # check that we now get the photo in the site object
         photos = self.get_photos()
         self.assertEqual(len(photos), 1)
-        self.assertEqual("/api/media/{}".format(data[0]), photos[0])
+        self.assertEqual("/media/{}".format(data[0]), photos[0]['url'])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_sites.py
+++ b/backend/tests/test_sites.py
@@ -99,13 +99,30 @@ class VisitsTestCase(unittest.TestCase):
         site = data['features'][0]['properties']
         self.assertEqual(site['last_visit']['id_visit'], visit2['id_visit'])
 
+    def get_photos(self):
+        resp = getrequest("sites/{}".format(self.site_id))
+        return resp.json()['features'][0]['properties']['photos']
+
     def test_post_photo(self):
+        # check that there is currently no photos on the visit
+        photos = self.get_photos()
+        self.assertEqual(len(photos), 0)
+
+        # post a photo
         response = postrequest(
             "sites/{}/visits/{}/photos".format(self.site_id, self.visit['id_visit']),
             None,
             file="../frontend/src/assets/Azure-Commun-019.JPG")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()), 1)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertIn("mares_{}".format(self.site_id), data[0])
+
+        # check that we now get the photo in the site object
+        photos = self.get_photos()
+        self.assertEqual(len(photos), 1)
+        self.assertEqual("/api/media/{}".format(data[0]), photos[0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_sites.py
+++ b/backend/tests/test_sites.py
@@ -73,6 +73,7 @@ class VisitsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.site_id = data['features'][0]['properties']['id_site']
+        self.visit = self.create_visit()
 
     def create_visit(self):
         response = postrequest("sites/{}/visits".format(self.site_id),
@@ -98,6 +99,13 @@ class VisitsTestCase(unittest.TestCase):
         site = data['features'][0]['properties']
         self.assertEqual(site['last_visit']['id_visit'], visit2['id_visit'])
 
+    def test_post_photo(self):
+        response = postrequest(
+            "sites/{}/visits/{}/photos".format(self.site_id, self.visit['id_visit']),
+            None,
+            file="../frontend/src/assets/Azure-Commun-019.JPG")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/app/programs/sites/detail/detail.component.html
+++ b/frontend/src/app/programs/sites/detail/detail.component.html
@@ -40,8 +40,8 @@
           <img class="card-img-top" data-src="holder.js/100px225?theme=thumb&amp;bg=55595c&amp;fg=eceeef&amp;text=Thumbnail" alt="Thumbnail [100%x225]" style="height: 225px; width: 100%; display: block;"
                src="{{ photo.url }}" data-holder-rendered="true">
           <div class="card-body">
-            <p class="card-text">{{ photo.description }}</p>
-            <p class="card-text"><small class="text-muted">{{ photo.date | date : longDate }}</small></p>
+            <p class="card-text">{{ photo.date | date : longDate }}</p>
+            <p class="card-text"><small class="text-muted">{{ photo.author }}</small></p>
           </div>
         </div>
       </div>
@@ -67,14 +67,14 @@
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel">{{ clickedPhoto?.description }}</h5>
+        <h5 class="modal-title" id="exampleModalLabel">{{ clickedPhoto?.date | date : longDate}}</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">
         <img src="{{ clickedPhoto?.url }}" style="width: 100%;">
-        <p class="card-text"><small class="text-muted">{{ clickedPhoto?.date }}</small></p>
+        <p class="card-text"><small class="text-muted">{{ clickedPhoto?.author }}</small></p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/frontend/src/app/programs/sites/detail/detail.component.html
+++ b/frontend/src/app/programs/sites/detail/detail.component.html
@@ -41,7 +41,7 @@
                src="{{ photo.url }}" data-holder-rendered="true">
           <div class="card-body">
             <p class="card-text">{{ photo.description }}</p>
-            <p class="card-text"><small class="text-muted">{{ photo.date }}</small></p>
+            <p class="card-text"><small class="text-muted">{{ photo.date | date : longDate }}</small></p>
           </div>
         </div>
       </div>

--- a/frontend/src/app/programs/sites/detail/detail.component.ts
+++ b/frontend/src/app/programs/sites/detail/detail.component.ts
@@ -23,16 +23,6 @@ export class SiteDetailComponent implements AfterViewInit {
   site: any;
   attributes = [];
   photos = [];
-  //   [{
-  //   url: "../../assets/Azure-Commun-019.JPG",
-  //   description: "Photo - Anonyme",
-  //   date: "15 mars 2019"
-  // }, {
-  //   url: "../../assets/faune-mercantour.jpg",
-  //   description: "des bébêtes - Anonyme",
-  //   date: "15 mars 2019"
-  // }
-  // ];
   clickedPhoto: any;
 
   constructor(
@@ -53,11 +43,10 @@ export class SiteDetailComponent implements AfterViewInit {
         console.log(sites);
         this.site = sites['features'][0];
 
-        var photos = this.site.properties.photos;
-        for (var i = 0; i<photos.length; i++){
-          photos[i]['url'] = AppConfig.API_ENDPOINT + photos[i]['url'];
+        this.photos = this.site.properties.photos;
+        for (var i = 0; i<this.photos.length; i++){
+          this.photos[i]['url'] = AppConfig.API_ENDPOINT + this.photos[i]['url'];
         }
-        this.photos = photos;
 
         // setup map
         const map = L.map("map");

--- a/frontend/src/app/programs/sites/detail/detail.component.ts
+++ b/frontend/src/app/programs/sites/detail/detail.component.ts
@@ -3,6 +3,7 @@ import {GncProgramsService} from "../../../api/gnc-programs.service";
 import {ActivatedRoute} from "@angular/router";
 import * as L from "leaflet";
 import MaresJson from '../../../../../../config/custom/form/mares.json';
+import {AppConfig} from "../../../../conf/app.config";
 
 declare let $: any;
 
@@ -21,16 +22,17 @@ export class SiteDetailComponent implements AfterViewInit {
   program_id: any;
   site: any;
   attributes = [];
-  photos = [{
-    url: "../../assets/Azure-Commun-019.JPG",
-    description: "Photo - Anonyme",
-    date: "15 mars 2019"
-  }, {
-    url: "../../assets/faune-mercantour.jpg",
-    description: "des bébêtes - Anonyme",
-    date: "15 mars 2019"
-  }
-  ];
+  photos = [];
+  //   [{
+  //   url: "../../assets/Azure-Commun-019.JPG",
+  //   description: "Photo - Anonyme",
+  //   date: "15 mars 2019"
+  // }, {
+  //   url: "../../assets/faune-mercantour.jpg",
+  //   description: "des bébêtes - Anonyme",
+  //   date: "15 mars 2019"
+  // }
+  // ];
   clickedPhoto: any;
 
   constructor(
@@ -50,6 +52,12 @@ export class SiteDetailComponent implements AfterViewInit {
 
         console.log(sites);
         this.site = sites['features'][0];
+
+        var photos = this.site.properties.photos;
+        for (var i = 0; i<photos.length; i++){
+          photos[i]['url'] = AppConfig.API_ENDPOINT + photos[i]['url'];
+        }
+        this.photos = photos;
 
         // setup map
         const map = L.map("map");


### PR DESCRIPTION
https://github.com/jolleon/GeoNature-citizen/issues/20

Tout le backend pour uploader et charger des photos + frontend page details d'un site utilise maintenant les vraies photos.

L'upload de photos se fait sur un endpoint propre `POST /api/sites/{site_id}/visits/{visit_id}/photos`, pas en même temps que la création d'une visite (c'était plus propre à implementer comme ça et ça permettra dans le futur de rajouter des photos sur une visite existante et de splitter l'upload en plusieurs requetes si nécessaire dans le cas ou un utilisateur ajoute plusieurs photos en même temps).

Ne manque plus que d'ajouter l'upload sur le frontend dans le formulaire.