### PR TITLE
Reactive login buttons when topbar is hidden

### DIFF
--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -2,12 +2,16 @@
     margin-top: 106px;
 }
 
+@media screen and (max-width: 991px) {
+   .app-no-topbar {
+          margin-top: 65px !important;
+   }
+}
+
 @media screen and (max-width: 576px){
     .app-with-topbar {
         margin-top: 65px !important;
     }
 }
 
-.app-no-topbar {
 
-}

--- a/frontend/src/app/core/topbar/topbar.component.css
+++ b/frontend/src/app/core/topbar/topbar.component.css
@@ -1,4 +1,4 @@
-.navbar {
+.navbar-visible {
   min-height: 100px;
   background-color: #fefefe;
   /* color: #60a3bc; */
@@ -90,7 +90,7 @@ div.btn-group a:first-child{
   font-weight: bold;
 }
 
- @media screen and (max-width: 992px){
+ @media screen and (max-width: 991px){
   /* FIXME: la nav bar ne se referme qu'à 768, pourquoi 912 ? */
 /*    .navbar-collapse form{
     justify-content: flex-end;
@@ -102,6 +102,14 @@ div.btn-group a:first-child{
   ul.btn-group li{/*
     min-width: 120px !important; */
     max-width: 120px !important;
+  }
+
+  .navbar-hidden {
+    pointer-events: auto;
+    min-height: 65px !important;
+  }
+  .navbar-hidden img{
+    height: 40px
   }
 }
 

--- a/frontend/src/app/core/topbar/topbar.component.html
+++ b/frontend/src/app/core/topbar/topbar.component.html
@@ -1,6 +1,6 @@
 <nav
-  class="navbar-light navbar-expand-md fixed-top"
-  [ngClass]="displayTopbar ? 'navbar' : 'navbar-hidden'"
+  class="navbar navbar-light navbar-expand-md fixed-top"
+  [ngClass]="displayTopbar ? 'navbar-visible' : 'navbar-hidden'"
 >
   <a
     class="navbar-brand"


### PR DESCRIPTION
fix #38 

Remet la topbar visible pour les boutons de login quand screen < 991px (à ce niveau la map passe en dessous de la liste).

Pas trop cherché à compliquer car il faudra vérifier comment ça se comporte après intégration dans WP.