### PR TITLE
Photo upload

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1266,6 +1266,14 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
+    "angular2-image-upload": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/angular2-image-upload/-/angular2-image-upload-1.0.0-rc.2.tgz",
+      "integrity": "sha512-chAmGu7iPy44a40ATEKspQRkRlYRewYkX78OxrzPf9rix4QM+q1MTJIt4KcmiBjdSPMc9zm1qIIsBVv0gpg5Kg==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "angular6-json-schema-form": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/angular6-json-schema-form/-/angular6-json-schema-form-7.1.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@ng-bootstrap/ng-bootstrap": "^3.2.2",
     "@nguniversal/express-engine": "^7.1.0",
     "@nguniversal/module-map-ngfactory-loader": "0.0.0",
+    "angular2-image-upload": "^1.0.0-rc.2",
     "angular6-json-schema-form": "^7.1.0",
     "bootstrap": "^4.3.1",
     "core-js": "^2.5.4",

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -68,6 +68,7 @@ registerLocaleData(localeFr, "fr");
 // registerLocaleData(localeFr, "fr-FR", localeFrExtra);
 import { Bootstrap4FrameworkModule } from 'angular6-json-schema-form';
 import { GNCFrameworkComponent } from './programs/sites/form/framework/framework.component';
+import {ImageUploadModule} from "angular2-image-upload";
 
 @NgModule({
   imports: [
@@ -78,6 +79,7 @@ import { GNCFrameworkComponent } from './programs/sites/form/framework/framework
     FormsModule,
     NgbModule,
     routing,
+    ImageUploadModule.forRoot(),
     Bootstrap4FrameworkModule
   ],
   declarations: [

--- a/frontend/src/app/programs/sites/form/form.component.css
+++ b/frontend/src/app/programs/sites/form/form.component.css
@@ -19,3 +19,13 @@
   min-height: 225px; /*50vh*/
   width: 100%;
 }
+
+.img-ul-upload {
+  background-color: var(--primary) !important;
+  font-size: 1em !important;
+}
+
+.img-ul-clear {
+  background-color: var(--secondary) !important;
+  font-size: 1em !important;
+}

--- a/frontend/src/app/programs/sites/form/form.component.css
+++ b/frontend/src/app/programs/sites/form/form.component.css
@@ -29,3 +29,7 @@
   background-color: var(--secondary) !important;
   font-size: 1em !important;
 }
+
+.hidden {
+  display: none!important;
+}

--- a/frontend/src/app/programs/sites/form/form.component.html
+++ b/frontend/src/app/programs/sites/form/form.component.html
@@ -7,20 +7,29 @@
   </h3>
   <p class="h6">{{ jsonSchema.steps[currentStep-1].description }}</p>
   <form id="visitForm" [formGroup]="visitForm">
-    <div class="input-group" *ngIf="currentStep === 1">
-      <label for="date" >Date de la visite</label>
-      <input
-        formControlName="date"
-        type="text"
-        class="form-control rounded-0"
-        placeholder="yyyy-mm-dd"
-        ngbDatepicker
-        #d="ngbDatepicker"
-        (click)="d.toggle()"
-      />
-      <image-upload
-        (uploadFinished)="addImage($event)"
-      ></image-upload>
+    <div class="row" *ngIf="currentStep === 1">
+      <div class="col-md-4">
+        <div class="input-group">
+          <label for="date" >Date de la visite</label>
+          <input
+            formControlName="date"
+            type="text"
+            class="form-control rounded-0"
+            placeholder="yyyy-mm-dd"
+            ngbDatepicker
+            #d="ngbDatepicker"
+            (click)="d.toggle()"
+          />
+        </div>
+      </div>
+      <div class="col-md-8">
+        <image-upload
+          buttonCaption="Ajouter une photo"
+          dropBoxMessage="Déposez vos photos ici !"
+          clearButtonCaption="Supprimer"
+          (uploadFinished)="addImage($event)"
+        ></image-upload>
+      </div>
     </div>
   </form>
 

--- a/frontend/src/app/programs/sites/form/form.component.html
+++ b/frontend/src/app/programs/sites/form/form.component.html
@@ -18,8 +18,12 @@
         #d="ngbDatepicker"
         (click)="d.toggle()"
       />
+      <image-upload
+        (uploadFinished)="addImage($event)"
+      ></image-upload>
     </div>
   </form>
+
   <json-schema-form
   [form]="formInputObject"
   [options]="formOptions"

--- a/frontend/src/app/programs/sites/form/form.component.html
+++ b/frontend/src/app/programs/sites/form/form.component.html
@@ -7,7 +7,7 @@
   </h3>
   <p class="h6">{{ jsonSchema.steps[currentStep-1].description }}</p>
   <form id="visitForm" [formGroup]="visitForm">
-    <div class="row" *ngIf="currentStep === 1">
+    <div class="row" [ngClass]="currentStep === 1 ? '' : 'hidden'">
       <div class="col-md-4">
         <div class="input-group">
           <label for="date" >Date de la visite</label>

--- a/frontend/src/app/programs/sites/form/form.component.html
+++ b/frontend/src/app/programs/sites/form/form.component.html
@@ -28,6 +28,7 @@
           dropBoxMessage="Déposez vos photos ici !"
           clearButtonCaption="Supprimer"
           (uploadFinished)="addImage($event)"
+          (removed)="deleteImage($event)"
         ></image-upload>
       </div>
     </div>

--- a/frontend/src/app/programs/sites/form/form.component.ts
+++ b/frontend/src/app/programs/sites/form/form.component.ts
@@ -121,14 +121,20 @@ export class SiteVisitFormComponent implements OnInit, AfterViewInit {
     this.updatePartialLayout();
   }
   addImage(event) {
-    console.log(event);
     this.photos.push(event.file);
-    console.log(this.photos);
   }
   onFormSubmit(): void {
     console.debug("formValues:", this.visitForm.value);
     this.postSiteVisit().subscribe(
-      data => console.debug(data),
+      data => {
+        console.debug(data);
+        let visitId = data["features"][0]["id_visit"];
+        this.postVisitPhotos(visitId).subscribe(
+          resp => console.debug(resp),
+          err => console.error(err),
+          () => console.log("photo upload done")
+        );
+      },
       err => console.error(err),
       () => console.log("done")
       // TODO: queue obs in list
@@ -153,5 +159,18 @@ export class SiteVisitFormComponent implements OnInit, AfterViewInit {
       this.visitForm.value,
       httpOptions
     );
+  }
+
+  postVisitPhotos(visitId: number) {
+    let formData = new FormData();
+    this.photos.forEach((file) => {
+        formData.append('file', file);
+      }
+    );
+    return this.http.post<any>(
+      `${this.URL}/sites/${this.site_id}/visits/${visitId}/photos`,
+      formData
+    );
+
   }
 }

--- a/frontend/src/app/programs/sites/form/form.component.ts
+++ b/frontend/src/app/programs/sites/form/form.component.ts
@@ -63,6 +63,8 @@ export class SiteVisitFormComponent implements OnInit, AfterViewInit {
   };
   formInputObject: any = {};
 
+  photos = [];
+
   constructor(private http: HttpClient, private route: ActivatedRoute) {}
 
   ngOnInit() {
@@ -117,6 +119,11 @@ export class SiteVisitFormComponent implements OnInit, AfterViewInit {
   toogleAdvancedMode() {
     this.advancedMode = !this.advancedMode;
     this.updatePartialLayout();
+  }
+  addImage(event) {
+    console.log(event);
+    this.photos.push(event.file);
+    console.log(this.photos);
   }
   onFormSubmit(): void {
     console.debug("formValues:", this.visitForm.value);

--- a/frontend/src/app/programs/sites/form/form.component.ts
+++ b/frontend/src/app/programs/sites/form/form.component.ts
@@ -123,6 +123,13 @@ export class SiteVisitFormComponent implements OnInit, AfterViewInit {
   addImage(event) {
     this.photos.push(event.file);
   }
+  deleteImage(event) {
+    for (var i=0; i<this.photos.length; i++) {
+      if (this.photos[i] == event.file) {
+        this.photos.splice(i, 1);
+      }
+    }
+  }
   onFormSubmit(): void {
     console.debug("formValues:", this.visitForm.value);
     this.postSiteVisit().subscribe(


### PR DESCRIPTION
fix https://github.com/jolleon/GeoNature-citizen/issues/20

Ajoute la possibilité d'uploader des photos lors de la creation d'une visite.
Utilise le widget https://github.com/aberezkin/ng2-image-upload

Comme il faut avoir un `visitId` pour pouvoir uploader des photos je n'ai pas pu utiliser la méthod d'upload incluse dans le widget mais l'ai implementé directement: les photos sont gardées en mémoire jusqu'à la fin du formulaire puis postées en formData.